### PR TITLE
Make mapNumber static

### DIFF
--- a/src/region_map.c
+++ b/src/region_map.c
@@ -47,7 +47,7 @@
 
 #define FLYDESTICON_RED_OUTLINE 6
 
-u8 mapNumber;
+static u8 mapNumber;
 
 enum {
     TAG_CURSOR,


### PR DESCRIPTION
## Summary
- limit `mapNumber` in `region_map.c` to file scope since no external files reference it

## Testing
- `git grep -R "mapNumber"`

------
https://chatgpt.com/codex/tasks/task_e_687a99e1c3cc8323a5d0952025bcf83b