### PR TITLE
Add constant for Ruins sliding door

### DIFF
--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -551,7 +551,8 @@
 #define METATILE_Route8_UndergroundPass_Door  0x2CE
 
 // gTileset_Ruins
-#define METATILE_Ruins_Of_Alph_Door  0x323
+#define METATILE_Ruins_Of_Alph_Door         0x323
+#define METATILE_Ruins_Of_Alph_SlidingDoor  0x3B0
 
 // gTileset_Rustboro
 #define METATILE_Rustboro_Door_Gray  0x21F

--- a/src/field_door.c
+++ b/src/field_door.c
@@ -373,7 +373,7 @@ static const struct DoorGraphics sDoorAnimGraphicsTable[] =
     {METATILE_Shop_Door_Elevator,                           DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_LilycoveDeptStoreElevator, sDoorAnimPalettes_LilycoveDeptStoreElevator},
     {METATILE_Dewford_Door_BattleTower,                     DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_BattleTowerOld, sDoorAnimPalettes_BattleTowerOld},
     {METATILE_BattleFrontier_Door_Elevator,                 DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_BattleTowerElevator, sDoorAnimPalettes_BattleTowerElevator},
-    {0x3B0, /* TODO: Missing metatile ID */                 DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_34, sDoorAnimPalettes_34},
+    {METATILE_Ruins_Of_Alph_SlidingDoor,                 DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_34, sDoorAnimPalettes_34},
     {METATILE_BattleFrontierOutsideWest_Door_BattleDome,    DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_BattleDome, sDoorAnimPalettes_BattleDome},
     {METATILE_BattleFrontierOutsideWest_Door_BattleFactory, DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_BattleFactory, sDoorAnimPalettes_BattleFactory},
     {METATILE_BattleFrontierOutsideEast_Door_BattleTower,   DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_BattleTower, sDoorAnimPalettes_BattleTower},


### PR DESCRIPTION
## Summary
- add `METATILE_Ruins_Of_Alph_SlidingDoor` constant
- replace hardcoded `0x3B0` in door animation table

## Testing
- `make -j4` *(fails: JSONPROC_ERROR variable 'map_section.id' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a99e5b2288323bdda97022be3ebe4