### PR TITLE
Fix missing Sootopolis Gym constants and functions

### DIFF
--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -879,6 +879,12 @@
 #define METATILE_Sootopolis_GymDoor_Closed   0x250
 #define METATILE_Sootopolis_RoughWater       0x290
 
+// gTileset_SootopolisGym
+#define METATILE_SootopolisGym_Ice          0x20D
+#define METATILE_SootopolisGym_Ice_Cracked  0x20E
+#define METATILE_SootopolisGym_Ice_Broken   0x206
+#define METATILE_SootopolisGym_Stairs       0x20F
+
 // gTileset_Sprout
 #define METATILE_Sprout_Tower_Door  0x294
 

--- a/include/event_object_movement.h
+++ b/include/event_object_movement.h
@@ -130,6 +130,8 @@ u8 SpawnSpecialObjectEventParameterized(u8 graphicsId, u8 movementBehavior, u8 l
 u8 SpawnSpecialObjectEvent(struct ObjectEventTemplate *objectEventTemplate);
 void SetSpritePosToMapCoords(s16 mapX, s16 mapY, s16 *destX, s16 *destY);
 void CameraObjectReset(void);
+#define CameraObjectReset1 CameraObjectReset
+#define CameraObjectReset2 CameraObjectReset
 void ObjectEventSetGraphicsId(struct ObjectEvent *objectEvent, u8 graphicsId);
 void ObjectEventTurn(struct ObjectEvent *objectEvent, u8 direction);
 void ObjectEventTurnByLocalIdAndMap(u8 localId, u8 mapNum, u8 mapGroup, u8 direction);

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -7,6 +7,7 @@
 #include "field_effect.h"
 #include "field_effect_helpers.h"
 #include "field_screen_effect.h"
+#include "field_control_avatar.h"
 #include "field_player_avatar.h"
 #include "fieldmap.h"
 #include "menu.h"


### PR DESCRIPTION
## Summary
- add missing Sootopolis Gym metatile labels
- alias missing camera reset helpers
- include field_control_avatar for boulder function

## Testing
- `make -j2` *(fails: arm-none-eabi-as: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687a9cb4bc748323975bdc8d8c747995