### PR TITLE
Fix compile errors by adding missing Lilycove door constants

### DIFF
--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -359,6 +359,12 @@
 #define METATILE_LilycoveMuseum_Painting4_Left   0x262
 #define METATILE_LilycoveMuseum_Painting4_Right  0x263
 
+// gTileset_Lilycove
+#define METATILE_Lilycove_Door             0x3F6
+#define METATILE_Lilycove_Door_Wooden      0x3F7
+#define METATILE_Lilycove_Door_DeptStore   0x3F8
+#define METATILE_Lilycove_Door_SafariZone  0x3F9
+
 // gTileset_Mauville
 #define METATILE_Mauville_DeepSand_BottomMid  0x259
 #define METATILE_Mauville_DeepSand_Center     0x251


### PR DESCRIPTION
## Summary
- define Lilycove door metatile constants

## Testing
- `make -j4` *(fails: `arm-none-eabi-as: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_687aa30d2f548323995b01c57d289dfe