### PR TITLE
Fix duplicates in region map data

### DIFF
--- a/include/constants/region_map_sections.h
+++ b/include/constants/region_map_sections.h
@@ -1,271 +1,275 @@
-#ifndef GUARD_REGIONMAPSEC_H
-#define GUARD_REGIONMAPSEC_H
+//
+// DO NOT MODIFY THIS FILE! It is auto-generated from src/data/region_map/region_map_sections.json and Inja template src/data/region_map/region_map_sections.constants.json.txt
+//
 
-#define MAPSEC_LITTLEROOT_TOWN              0x00
-#define MAPSEC_OLDALE_TOWN                  0x01
-#define MAPSEC_DEWFORD_TOWN                 0x02
-#define MAPSEC_LAVARIDGE_TOWN               0x03
-#define MAPSEC_FALLARBOR_TOWN               0x04
-#define MAPSEC_VERDANTURF_TOWN              0x05
-#define MAPSEC_PACIFIDLOG_TOWN              0x06
-#define MAPSEC_PETALBURG_CITY               0x07
-#define MAPSEC_SLATEPORT_CITY               0x08
-#define MAPSEC_MAUVILLE_CITY                0x09
-#define MAPSEC_RUSTBORO_CITY                0x0A
-#define MAPSEC_FORTREE_CITY                 0x0B
-#define MAPSEC_LILYCOVE_CITY                0x0C
-#define MAPSEC_MOSSDEEP_CITY                0x0D
-#define MAPSEC_SOOTOPOLIS_CITY              0x0E
-#define MAPSEC_EVER_GRANDE_CITY             0x0F
-#define MAPSEC_ROUTE_101                    0x10
-#define MAPSEC_ROUTE_102                    0x11
-#define MAPSEC_ROUTE_103                    0x12
-#define MAPSEC_ROUTE_104                    0x13
-#define MAPSEC_ROUTE_105                    0x14
-#define MAPSEC_ROUTE_106                    0x15
-#define MAPSEC_ROUTE_107                    0x16
-#define MAPSEC_ROUTE_108                    0x17
-#define MAPSEC_ROUTE_109                    0x18
-#define MAPSEC_ROUTE_110                    0x19
-#define MAPSEC_ROUTE_111                    0x1A
-#define MAPSEC_ROUTE_112                    0x1B
-#define MAPSEC_ROUTE_113                    0x1C
-#define MAPSEC_ROUTE_114                    0x1D
-#define MAPSEC_ROUTE_115                    0x1E
-#define MAPSEC_ROUTE_116                    0x1F
-#define MAPSEC_ROUTE_117                    0x20
-#define MAPSEC_ROUTE_118                    0x21
-#define MAPSEC_ROUTE_119                    0x22
-#define MAPSEC_ROUTE_120                    0x23
-#define MAPSEC_ROUTE_121                    0x24
-#define MAPSEC_ROUTE_122                    0x25
-#define MAPSEC_ROUTE_123                    0x26
-#define MAPSEC_ROUTE_124                    0x27
-#define MAPSEC_ROUTE_125                    0x28
-#define MAPSEC_ROUTE_126                    0x29
-#define MAPSEC_ROUTE_127                    0x2A
-#define MAPSEC_ROUTE_128                    0x2B
-#define MAPSEC_ROUTE_129                    0x2C
-#define MAPSEC_ROUTE_130                    0x2D
-#define MAPSEC_ROUTE_131                    0x2E
-#define MAPSEC_ROUTE_132                    0x2F
-#define MAPSEC_ROUTE_133                    0x30
-#define MAPSEC_ROUTE_134                    0x31
-#define MAPSEC_UNDERWATER_124               0x32
-#define MAPSEC_UNDERWATER_126               0x33
-#define MAPSEC_UNDERWATER_127               0x34
-#define MAPSEC_UNDERWATER_128               0x35
-#define MAPSEC_UNDERWATER_SOOTOPOLIS        0x36
-#define MAPSEC_GRANITE_CAVE                 0x37
-#define MAPSEC_MT_CHIMNEY                   0x38
-#define MAPSEC_SAFARI_ZONE                  0x39
-#define MAPSEC_BATTLE_FRONTIER              0x3A
-#define MAPSEC_PETALBURG_WOODS              0x3B
-#define MAPSEC_RUSTURF_TUNNEL               0x3C
-#define MAPSEC_ABANDONED_SHIP               0x3D
-#define MAPSEC_NEW_MAUVILLE                 0x3E
-#define MAPSEC_METEOR_FALLS                 0x3F
-#define MAPSEC_MT_PYRE                      0x40
-#define MAPSEC_AQUA_HIDEOUT_OLD             0x41
-#define MAPSEC_SHOAL_CAVE                   0x42
-#define MAPSEC_SEAFLOOR_CAVERN              0x43
-#define MAPSEC_UNDERWATER_SEAFLOOR_CAVERN   0x44
-#define MAPSEC_VICTORY_ROAD                 0x45
-#define MAPSEC_MIRAGE_ISLAND                0x46
-#define MAPSEC_CAVE_OF_ORIGIN               0x47
-#define MAPSEC_SOUTHERN_ISLAND              0x48
-#define MAPSEC_FIERY_PATH                   0x49
-#define MAPSEC_JAGGED_PASS                  0x4A
-#define MAPSEC_SEALED_CHAMBER               0x4B
-#define MAPSEC_UNDERWATER_SEALED_CHAMBER    0x4C
-#define MAPSEC_SCORCHED_SLAB                0x4D
-#define MAPSEC_ISLAND_CAVE                  0x4E
-#define MAPSEC_DESERT_RUINS                 0x4F
-#define MAPSEC_ANCIENT_TOMB                 0x50
-#define MAPSEC_INSIDE_OF_TRUCK              0x51
-#define MAPSEC_SKY_PILLAR                   0x52
-#define MAPSEC_SECRET_BASE                  0x53
-#define MAPSEC_DYNAMIC                      0x54
-#define MAPSEC_PALLET_TOWN                  0x55
-#define MAPSEC_VIRIDIAN_CITY                0x56
-#define MAPSEC_PEWTER_CITY                  0x57
-#define MAPSEC_CERULEAN_CITY                0x58
-#define MAPSEC_LAVENDER_TOWN                0x59
-#define MAPSEC_VERMILION_CITY               0x5A
-#define MAPSEC_CELADON_CITY                 0x5B
-#define MAPSEC_FUCHSIA_CITY                 0x5C
-#define MAPSEC_CINNABAR_ISLAND              0x5D
-#define MAPSEC_INDIGO_PLATEAU               0x5E
-#define MAPSEC_SAFFRON_CITY                 0x5F
-#define MAPSEC_ROUTE_1                      0x60
-#define MAPSEC_ROUTE_2                      0x61
-#define MAPSEC_ROUTE_3                      0x62
-#define MAPSEC_ROUTE_4                      0x63
-#define MAPSEC_ROUTE_5                      0x64
-#define MAPSEC_ROUTE_6                      0x65
-#define MAPSEC_ROUTE_7                      0x66
-#define MAPSEC_ROUTE_8                      0x67
-#define MAPSEC_ROUTE_9                      0x68
-#define MAPSEC_ROUTE_10                     0x69
-#define MAPSEC_ROUTE_11                     0x6A
-#define MAPSEC_ROUTE_12                     0x6B
-#define MAPSEC_ROUTE_13                     0x6C
-#define MAPSEC_ROUTE_14                     0x6D
-#define MAPSEC_ROUTE_15                     0x6E
-#define MAPSEC_ROUTE_16                     0x6F
-#define MAPSEC_ROUTE_17                     0x70
-#define MAPSEC_ROUTE_18                     0x71
-#define MAPSEC_ROUTE_19                     0x72
-#define MAPSEC_ROUTE_20                     0x73
-#define MAPSEC_ROUTE_21                     0x74
-#define MAPSEC_ROUTE_22                     0x75
-#define MAPSEC_ROUTE_23                     0x76
-#define MAPSEC_ROUTE_24                     0x77
-#define MAPSEC_ROUTE_25                     0x78
-#define MAPSEC_VIRIDIAN_FOREST              0x79
-#define MAPSEC_MT_MOON                      0x7A
-#define MAPSEC_S_S_ANNE                     0x7B
-#define MAPSEC_UNDERGROUND_PATH             0x7C
-#define MAPSEC_UNDERGROUND_PATH_2           0x7D
-#define MAPSEC_DIGLETTS_CAVE                0x7E
-#define MAPSEC_KANTO_VICTORY_ROAD           0x7F
-#define MAPSEC_ROCKET_HIDEOUT               0x80
-#define MAPSEC_SILPH_CO                     0x81
-#define MAPSEC_POKEMON_MANSION              0x82
-#define MAPSEC_KANTO_SAFARI_ZONE            0x83
-#define MAPSEC_POKEMON_LEAGUE               0x84
-#define MAPSEC_ROCK_TUNNEL                  0x85
-#define MAPSEC_SEAFOAM_ISLANDS              0x86
-#define MAPSEC_POKEMON_TOWER                0x87
-#define MAPSEC_CERULEAN_CAVE                0x88
-#define MAPSEC_POWER_PLANT                  0x89
-#define MAPSEC_ONE_ISLAND                   0x8A
-#define MAPSEC_TWO_ISLAND                   0x8B
-#define MAPSEC_THREE_ISLAND                 0x8C
-#define MAPSEC_FOUR_ISLAND                  0x8D
-#define MAPSEC_FIVE_ISLAND                  0x8E
-#define MAPSEC_SEVEN_ISLAND                 0x8F
-#define MAPSEC_SIX_ISLAND                   0x90
-#define MAPSEC_KINDLE_ROAD                  0x91
-#define MAPSEC_TREASURE_BEACH               0x92
-#define MAPSEC_CAPE_BRINK                   0x93
-#define MAPSEC_BOND_BRIDGE                  0x94
-#define MAPSEC_THREE_ISLE_PORT              0x95
-#define MAPSEC_SEVII_ISLE_6                 0x96
-#define MAPSEC_SEVII_ISLE_7                 0x97
-#define MAPSEC_SEVII_ISLE_8                 0x98
-#define MAPSEC_SEVII_ISLE_9                 0x99
-#define MAPSEC_RESORT_GORGEOUS              0x9A
-#define MAPSEC_WATER_LABYRINTH              0x9B
-#define MAPSEC_FIVE_ISLE_MEADOW             0x9C
-#define MAPSEC_MEMORIAL_PILLAR              0x9D
-#define MAPSEC_OUTCAST_ISLAND               0x9E
-#define MAPSEC_GREEN_PATH                   0x9F
-#define MAPSEC_WATER_PATH                   0xA0
-#define MAPSEC_RUIN_VALLEY                  0xA1
-#define MAPSEC_TRAINER_TOWER                0xA2
-#define MAPSEC_CANYON_ENTRANCE              0xA3
-#define MAPSEC_SEVAULT_CANYON               0xA4
-#define MAPSEC_TANOBY_RUINS                 0xA5
-#define MAPSEC_MT_EMBER                     0xA6
-#define MAPSEC_BERRY_FOREST                 0xA7
-#define MAPSEC_ICEFALL_CAVE                 0xA8
-#define MAPSEC_ROCKET_WAREHOUSE             0xA9
-#define MAPSEC_TRAINER_TOWER_2              0xAA
-#define MAPSEC_DOTTED_HOLE                  0xAB
-#define MAPSEC_LOST_CAVE                    0xAC
-#define MAPSEC_PATTERN_BUSH                 0xAD
-#define MAPSEC_ALTERING_CAVE_FRLG           0xAE
-#define MAPSEC_TANOBY_CHAMBERS              0xAF
-#define MAPSEC_THREE_ISLE_PATH              0xB0
-#define MAPSEC_TANOBY_KEY                   0xB1
-#define MAPSEC_MONEAN_CHAMBER               0xB2
-#define MAPSEC_LIPTOO_CHAMBER               0xB3
-#define MAPSEC_WEEPTH_CHAMBER               0xB4
-#define MAPSEC_DILFORD_CHAMBER              0xB5
-#define MAPSEC_SCUFIB_CHAMBER               0xB6
-#define MAPSEC_RIXY_CHAMBER                 0xB7
-#define MAPSEC_VIAPOIS_CHAMBER              0xB8
-#define MAPSEC_EMBER_SPA                    0xB9
-#define MAPSEC_SPECIAL_AREA                 0xBA
-#define MAPSEC_AQUA_HIDEOUT                 0xBB
-#define MAPSEC_MAGMA_HIDEOUT                0xBC
-#define MAPSEC_MIRAGE_TOWER                 0xBD
-#define MAPSEC_BIRTH_ISLAND                 0xBE
-#define MAPSEC_FARAWAY_ISLAND               0xBF
-#define MAPSEC_ARTISAN_CAVE                 0xC0
-#define MAPSEC_MARINE_CAVE                  0xC1
-#define MAPSEC_UNDERWATER_MARINE_CAVE       0xC2
-#define MAPSEC_TERRA_CAVE                   0xC3
-#define MAPSEC_UNDERWATER_105               0xC4
-#define MAPSEC_UNDERWATER_125               0xC5
-#define MAPSEC_UNDERWATER_129               0xC6
-#define MAPSEC_DESERT_UNDERPASS             0xC7
-#define MAPSEC_ALTERING_CAVE                0xC8
-#define MAPSEC_NAVEL_ROCK                   0xC9
-#define MAPSEC_TRAINER_HILL                 0xCA
-#define MAPSEC_NEW_BARK_TOWN                0xCB
-#define MAPSEC_CHERRYGROVE_CITY             0xCC
-#define MAPSEC_VIOLET_CITY                  0xCD
-#define MAPSEC_AZALEA_TOWN                  0xCE
-#define MAPSEC_GOLDENROD_CITY               0xCF
-#define MAPSEC_ECRUTEAK_CITY                0xD0
-#define MAPSEC_OLIVINE_CITY                 0xD1
-#define MAPSEC_CIANWOOD_CITY                0xD2
-#define MAPSEC_MAHOGANY_TOWN                0xD3
-#define MAPSEC_BLACKTHORN_CITY              0xD4
-#define MAPSEC_ROUTE_26                     0xD5
-#define MAPSEC_ROUTE_27                     0xD6
-#define MAPSEC_ROUTE_28                     0xD7
-#define MAPSEC_ROUTE_29                     0xD8
-#define MAPSEC_ROUTE_30                     0xD9
-#define MAPSEC_ROUTE_31                     0xDA
-#define MAPSEC_ROUTE_32                     0xDB
-#define MAPSEC_ROUTE_33                     0xDC
-#define MAPSEC_ROUTE_34                     0xDD
-#define MAPSEC_ROUTE_35                     0xDE
-#define MAPSEC_ROUTE_36                     0xDF
-#define MAPSEC_ROUTE_37                     0xE0
-#define MAPSEC_ROUTE_38                     0xE1
-#define MAPSEC_ROUTE_39                     0xE2
-#define MAPSEC_ROUTE_40                     0xE3
-#define MAPSEC_ROUTE_41                     0xE4
-#define MAPSEC_ROUTE_42                     0xE5
-#define MAPSEC_ROUTE_43                     0xE6
-#define MAPSEC_ROUTE_44                     0xE7
-#define MAPSEC_ROUTE_45                     0xE8
-#define MAPSEC_ROUTE_46                     0xE9
-#define MAPSEC_RUINS_OF_ALPH                0xEA
-#define MAPSEC_SLOWPOKE_WELL                0xEB
-#define MAPSEC_UNION_CAVE                   0xEC
-#define MAPSEC_ILEX_FOREST                  0xED
-#define MAPSEC_RADIO_TOWER                  0xEE
-#define MAPSEC_NATIONAL_PARK                0xEF
-#define MAPSEC_TIN_TOWER                    0xF0
-#define MAPSEC_BELL_TOWER                   0xF1
-#define MAPSEC_BURNED_TOWER                 0xF2
-#define MAPSEC_SPROUT_TOWER                 0xF3
-#define MAPSEC_WHIRL_ISLANDS                0xF4
-#define MAPSEC_DARK_CAVE                    0xF5
-#define MAPSEC_MT_MORTAR                    0xF6
-#define MAPSEC_ICE_PATH                     0xF7
-#define MAPSEC_LAKE_OF_RAGE                 0xF8
-#define MAPSEC_DRAGONS_DEN                  0xF9
-#define MAPSEC_TOHJO_FALLS                  0xFA
-#define MAPSEC_MT_SILVER                    0xFB
-#define MAPSEC_NONE                         0xFC
+#ifndef GUARD_CONSTANTS_REGION_MAP_SECTIONS_H
+#define GUARD_CONSTANTS_REGION_MAP_SECTIONS_H
 
-#define METLOC_SPECIAL_EGG                  0xFD
-#define METLOC_IN_GAME_TRADE                0xFE
-#define METLOC_FATEFUL_ENCOUNTER            0xFF
+enum {
+    MAPSEC_LITTLEROOT_TOWN,
+    MAPSEC_OLDALE_TOWN,
+    MAPSEC_DEWFORD_TOWN,
+    MAPSEC_LAVARIDGE_TOWN,
+    MAPSEC_FALLARBOR_TOWN,
+    MAPSEC_VERDANTURF_TOWN,
+    MAPSEC_PACIFIDLOG_TOWN,
+    MAPSEC_PETALBURG_CITY,
+    MAPSEC_SLATEPORT_CITY,
+    MAPSEC_MAUVILLE_CITY,
+    MAPSEC_RUSTBORO_CITY,
+    MAPSEC_FORTREE_CITY,
+    MAPSEC_LILYCOVE_CITY,
+    MAPSEC_MOSSDEEP_CITY,
+    MAPSEC_SOOTOPOLIS_CITY,
+    MAPSEC_EVER_GRANDE_CITY,
+    MAPSEC_ROUTE_101,
+    MAPSEC_ROUTE_102,
+    MAPSEC_ROUTE_103,
+    MAPSEC_ROUTE_104,
+    MAPSEC_ROUTE_105,
+    MAPSEC_ROUTE_106,
+    MAPSEC_ROUTE_107,
+    MAPSEC_ROUTE_108,
+    MAPSEC_ROUTE_109,
+    MAPSEC_ROUTE_110,
+    MAPSEC_ROUTE_111,
+    MAPSEC_ROUTE_112,
+    MAPSEC_ROUTE_113,
+    MAPSEC_ROUTE_114,
+    MAPSEC_ROUTE_115,
+    MAPSEC_ROUTE_116,
+    MAPSEC_ROUTE_117,
+    MAPSEC_ROUTE_118,
+    MAPSEC_ROUTE_119,
+    MAPSEC_ROUTE_120,
+    MAPSEC_ROUTE_121,
+    MAPSEC_ROUTE_122,
+    MAPSEC_ROUTE_123,
+    MAPSEC_ROUTE_124,
+    MAPSEC_ROUTE_125,
+    MAPSEC_ROUTE_126,
+    MAPSEC_ROUTE_127,
+    MAPSEC_ROUTE_128,
+    MAPSEC_ROUTE_129,
+    MAPSEC_ROUTE_130,
+    MAPSEC_ROUTE_131,
+    MAPSEC_ROUTE_132,
+    MAPSEC_ROUTE_133,
+    MAPSEC_ROUTE_134,
+    MAPSEC_UNDERWATER_124,
+    MAPSEC_UNDERWATER_126,
+    MAPSEC_UNDERWATER_127,
+    MAPSEC_UNDERWATER_128,
+    MAPSEC_UNDERWATER_SOOTOPOLIS,
+    MAPSEC_GRANITE_CAVE,
+    MAPSEC_MT_CHIMNEY,
+    MAPSEC_SAFARI_ZONE,
+    MAPSEC_BATTLE_FRONTIER,
+    MAPSEC_PETALBURG_WOODS,
+    MAPSEC_RUSTURF_TUNNEL,
+    MAPSEC_ABANDONED_SHIP,
+    MAPSEC_NEW_MAUVILLE,
+    MAPSEC_METEOR_FALLS,
+    MAPSEC_MT_PYRE,
+    MAPSEC_AQUA_HIDEOUT_OLD,
+    MAPSEC_SHOAL_CAVE,
+    MAPSEC_SEAFLOOR_CAVERN,
+    MAPSEC_UNDERWATER_SEAFLOOR_CAVERN,
+    MAPSEC_VICTORY_ROAD,
+    MAPSEC_MIRAGE_ISLAND,
+    MAPSEC_CAVE_OF_ORIGIN,
+    MAPSEC_SOUTHERN_ISLAND,
+    MAPSEC_FIERY_PATH,
+    MAPSEC_JAGGED_PASS,
+    MAPSEC_SEALED_CHAMBER,
+    MAPSEC_UNDERWATER_SEALED_CHAMBER,
+    MAPSEC_SCORCHED_SLAB,
+    MAPSEC_ISLAND_CAVE,
+    MAPSEC_DESERT_RUINS,
+    MAPSEC_ANCIENT_TOMB,
+    MAPSEC_INSIDE_OF_TRUCK,
+    MAPSEC_SKY_PILLAR,
+    MAPSEC_SECRET_BASE,
+    MAPSEC_PALLET_TOWN,
+    MAPSEC_VIRIDIAN_CITY,
+    MAPSEC_PEWTER_CITY,
+    MAPSEC_CERULEAN_CITY,
+    MAPSEC_LAVENDER_TOWN,
+    MAPSEC_VERMILION_CITY,
+    MAPSEC_CELADON_CITY,
+    MAPSEC_FUCHSIA_CITY,
+    MAPSEC_CINNABAR_ISLAND,
+    MAPSEC_INDIGO_PLATEAU,
+    MAPSEC_SAFFRON_CITY,
+    MAPSEC_ROUTE_1,
+    MAPSEC_ROUTE_2,
+    MAPSEC_ROUTE_3,
+    MAPSEC_ROUTE_4,
+    MAPSEC_ROUTE_5,
+    MAPSEC_ROUTE_6,
+    MAPSEC_ROUTE_7,
+    MAPSEC_ROUTE_8,
+    MAPSEC_ROUTE_9,
+    MAPSEC_ROUTE_10,
+    MAPSEC_ROUTE_11,
+    MAPSEC_ROUTE_12,
+    MAPSEC_ROUTE_13,
+    MAPSEC_ROUTE_14,
+    MAPSEC_ROUTE_15,
+    MAPSEC_ROUTE_16,
+    MAPSEC_ROUTE_17,
+    MAPSEC_ROUTE_18,
+    MAPSEC_ROUTE_19,
+    MAPSEC_ROUTE_20,
+    MAPSEC_ROUTE_21,
+    MAPSEC_ROUTE_22,
+    MAPSEC_ROUTE_23,
+    MAPSEC_ROUTE_24,
+    MAPSEC_ROUTE_25,
+    MAPSEC_VIRIDIAN_FOREST,
+    MAPSEC_MT_MOON,
+    MAPSEC_S_S_ANNE,
+    MAPSEC_UNDERGROUND_PATH,
+    MAPSEC_UNDERGROUND_PATH_2,
+    MAPSEC_KANTO_VICTORY_ROAD,
+    MAPSEC_ROCKET_HIDEOUT,
+    MAPSEC_SILPH_CO,
+    MAPSEC_POKEMON_MANSION,
+    MAPSEC_KANTO_SAFARI_ZONE,
+    MAPSEC_POKEMON_LEAGUE,
+    MAPSEC_ROCK_TUNNEL,
+    MAPSEC_SEAFOAM_ISLANDS,
+    MAPSEC_POKEMON_TOWER,
+    MAPSEC_CERULEAN_CAVE,
+    MAPSEC_POWER_PLANT,
+    MAPSEC_ONE_ISLAND,
+    MAPSEC_TWO_ISLAND,
+    MAPSEC_THREE_ISLAND,
+    MAPSEC_FOUR_ISLAND,
+    MAPSEC_FIVE_ISLAND,
+    MAPSEC_SEVEN_ISLAND,
+    MAPSEC_SIX_ISLAND,
+    MAPSEC_KINDLE_ROAD,
+    MAPSEC_TREASURE_BEACH,
+    MAPSEC_CAPE_BRINK,
+    MAPSEC_BOND_BRIDGE,
+    MAPSEC_THREE_ISLE_PORT,
+    MAPSEC_SEVII_ISLE_6,
+    MAPSEC_SEVII_ISLE_7,
+    MAPSEC_SEVII_ISLE_8,
+    MAPSEC_SEVII_ISLE_9,
+    MAPSEC_RESORT_GORGEOUS,
+    MAPSEC_WATER_LABYRINTH,
+    MAPSEC_FIVE_ISLE_MEADOW,
+    MAPSEC_MEMORIAL_PILLAR,
+    MAPSEC_OUTCAST_ISLAND,
+    MAPSEC_GREEN_PATH,
+    MAPSEC_WATER_PATH,
+    MAPSEC_RUIN_VALLEY,
+    MAPSEC_TRAINER_TOWER,
+    MAPSEC_CANYON_ENTRANCE,
+    MAPSEC_SEVAULT_CANYON,
+    MAPSEC_TANOBY_RUINS,
+    MAPSEC_SEVII_ISLE_22,
+    MAPSEC_SEVII_ISLE_23,
+    MAPSEC_SEVII_ISLE_24,
+    MAPSEC_NAVEL_ROCK_FRLG,
+    MAPSEC_BERRY_FOREST,
+    MAPSEC_ICEFALL_CAVE,
+    MAPSEC_ROCKET_WAREHOUSE,
+    MAPSEC_DOTTED_HOLE,
+    MAPSEC_LOST_CAVE,
+    MAPSEC_PATTERN_BUSH,
+    MAPSEC_MT_EMBER,
+    MAPSEC_TRAINER_TOWER_2,
+    MAPSEC_THREE_ISLE_PATH,
+    MAPSEC_TANOBY_KEY,
+    MAPSEC_MONEAN_CHAMBER,
+    MAPSEC_LIPTOO_CHAMBER,
+    MAPSEC_WEEPTH_CHAMBER,
+    MAPSEC_DILFORD_CHAMBER,
+    MAPSEC_SCUFIB_CHAMBER,
+    MAPSEC_RIXY_CHAMBER,
+    MAPSEC_VIAPOIS_CHAMBER,
+    MAPSEC_EMBER_SPA,
+    MAPSEC_SPECIAL_AREA,
+    MAPSEC_AQUA_HIDEOUT,
+    MAPSEC_MAGMA_HIDEOUT,
+    MAPSEC_MIRAGE_TOWER,
+    MAPSEC_BIRTH_ISLAND,
+    MAPSEC_FARAWAY_ISLAND,
+    MAPSEC_ARTISAN_CAVE,
+    MAPSEC_MARINE_CAVE,
+    MAPSEC_UNDERWATER_MARINE_CAVE,
+    MAPSEC_TERRA_CAVE,
+    MAPSEC_UNDERWATER_105,
+    MAPSEC_UNDERWATER_125,
+    MAPSEC_UNDERWATER_129,
+    MAPSEC_DESERT_UNDERPASS,
+    MAPSEC_ALTERING_CAVE,
+    MAPSEC_NAVEL_ROCK,
+    MAPSEC_TRAINER_HILL,
+    MAPSEC_NEW_BARK_TOWN,
+    MAPSEC_CHERRYGROVE_CITY,
+    MAPSEC_VIOLET_CITY,
+    MAPSEC_AZALEA_TOWN,
+    MAPSEC_GOLDENROD_CITY,
+    MAPSEC_ECRUTEAK_CITY,
+    MAPSEC_OLIVINE_CITY,
+    MAPSEC_CIANWOOD_CITY,
+    MAPSEC_MAHOGANY_TOWN,
+    MAPSEC_BLACKTHORN_CITY,
+    MAPSEC_ROUTE_26,
+    MAPSEC_ROUTE_27,
+    MAPSEC_ROUTE_28,
+    MAPSEC_ROUTE_29,
+    MAPSEC_ROUTE_30,
+    MAPSEC_ROUTE_31,
+    MAPSEC_ROUTE_32,
+    MAPSEC_ROUTE_33,
+    MAPSEC_ROUTE_34,
+    MAPSEC_ROUTE_35,
+    MAPSEC_ROUTE_36,
+    MAPSEC_ROUTE_37,
+    MAPSEC_ROUTE_38,
+    MAPSEC_ROUTE_39,
+    MAPSEC_ROUTE_40,
+    MAPSEC_ROUTE_41,
+    MAPSEC_ROUTE_42,
+    MAPSEC_ROUTE_43,
+    MAPSEC_ROUTE_44,
+    MAPSEC_ROUTE_45,
+    MAPSEC_ROUTE_46,
+    MAPSEC_RUINS_OF_ALPH,
+    MAPSEC_SLOWPOKE_WELL,
+    MAPSEC_UNION_CAVE,
+    MAPSEC_ILEX_FOREST,
+    MAPSEC_RADIO_TOWER,
+    MAPSEC_NATIONAL_PARK,
+    MAPSEC_TIN_TOWER,
+    MAPSEC_BELL_TOWER,
+    MAPSEC_BURNED_TOWER,
+    MAPSEC_SPROUT_TOWER,
+    MAPSEC_WHIRL_ISLANDS,
+    MAPSEC_DARK_CAVE,
+    MAPSEC_MT_MORTAR,
+    MAPSEC_LAKE_OF_RAGE,
+    MAPSEC_ICE_PATH,
+    MAPSEC_DRAGONS_DEN,
+    MAPSEC_TOHJO_FALLS,
+    MAPSEC_MT_SILVER,
+    MAPSEC_DYNAMIC,
+    MAPSEC_NONE,
+    MAPSEC_COUNT
+};
 
+// Special location IDs that use the same value space as MAPSECs.
+#define METLOC_SPECIAL_EGG         0xFD
+#define METLOC_IN_GAME_TRADE       0xFE
+#define METLOC_FATEFUL_ENCOUNTER   0xFF
 
 #define KANTO_MAPSEC_START  MAPSEC_PALLET_TOWN
 #define KANTO_MAPSEC_END    MAPSEC_SPECIAL_AREA
 #define KANTO_MAPSEC_COUNT (KANTO_MAPSEC_END - KANTO_MAPSEC_START + 1)
 
-#define JOHTO_MAPSEC_START  MAPSEC_NEW_BARK_TOWN
-#define JOHTO_MAPSEC_END    MAPSEC_MT_SILVER
-#define JOHTO_MAPSEC_COUNT (JOHTO_MAPSEC_END - JOHTO_MAPSEC_START + 1)
-
-#endif //GUARD_REGIONMAPSEC_H
+#endif // GUARD_CONSTANTS_REGION_MAP_SECTIONS_H

--- a/src/data/region_map/region_map_entries.h
+++ b/src/data/region_map/region_map_entries.h
@@ -125,7 +125,6 @@ static const u8 sMapName_MT__MOON[] = _("MT. MOON");
 static const u8 sMapName_S_S__ANNE[] = _("S.S. ANNE");
 static const u8 sMapName_UNDERGROUND_PATH[] = _("UNDERGROUND PATH");
 static const u8 sMapName_UNDERGROUND_PATH_Clone[] = _("UNDERGROUND PATH");
-static const u8 sMapName_DIGLETT_S_CAVE[] = _("DIGLETT'S CAVE");
 static const u8 sMapName_ROCKET_HIDEOUT[] = _("ROCKET HIDEOUT");
 static const u8 sMapName_SILPH_CO_[] = _("SILPH CO.");
 static const u8 sMapName_POK__MON_MANSION[] = _("POKéMON MANSION");
@@ -167,14 +166,16 @@ static const u8 sMapName_SEVII_ISLE_22[] = _("SEVII ISLE 22");
 static const u8 sMapName_SEVII_ISLE_23[] = _("SEVII ISLE 23");
 static const u8 sMapName_SEVII_ISLE_24[] = _("SEVII ISLE 24");
 static const u8 sMapName_NAVEL_ROCK[] = _("NAVEL ROCK");
-static const u8 sMapName_MT__EMBER[] = _("MT. EMBER");
 static const u8 sMapName_BERRY_FOREST[] = _("BERRY FOREST");
 static const u8 sMapName_ICEFALL_CAVE[] = _("ICEFALL CAVE");
 static const u8 sMapName_ROCKET_WAREHOUSE[] = _("ROCKET WAREHOUSE");
-static const u8 sMapName_TRAINER_TOWER_Clone[] = _("TRAINER TOWER");
 static const u8 sMapName_DOTTED_HOLE[] = _("DOTTED HOLE");
 static const u8 sMapName_LOST_CAVE[] = _("LOST CAVE");
 static const u8 sMapName_PATTERN_BUSH[] = _("PATTERN BUSH");
+static const u8 sMapName_MT__EMBER[] = _("MT. EMBER");
+static const u8 sMapName_TRAINER_TOWER_Clone[] = _("TRAINER TOWER");
+static const u8 sMapName_THREE_ISLE_PATH[] = _("THREE ISLE PATH");
+static const u8 sMapName_TANOBY_KEY[] = _("TANOBY KEY");
 static const u8 sMapName_MONEAN_CHAMBER[] = _("MONEAN CHAMBER");
 static const u8 sMapName_LIPTOO_CHAMBER[] = _("LIPTOO CHAMBER");
 static const u8 sMapName_WEEPTH_CHAMBER[] = _("WEEPTH CHAMBER");
@@ -184,9 +185,6 @@ static const u8 sMapName_RIXY_CHAMBER[] = _("RIXY CHAMBER");
 static const u8 sMapName_VIAPOIS_CHAMBER[] = _("VIAPOIS CHAMBER");
 static const u8 sMapName_EMBER_SPA[] = _("EMBER SPA");
 static const u8 sMapName_SPECIAL_AREA[] = _("SPECIAL AREA");
-static const u8 sMapName_THREE_ISLE_PATH[] = _("THREE ISLE PATH");
-static const u8 sMapName_TANOBY_KEY[] = _("TANOBY KEY");
-static const u8 sMapName_TANOBY_CHAMBERS[] = _("TANOBY CHAMBERS");
 static const u8 sMapName_AQUA_HIDEOUT[] = _("AQUA HIDEOUT");
 static const u8 sMapName_MAGMA_HIDEOUT[] = _("MAGMA HIDEOUT");
 static const u8 sMapName_MIRAGE_TOWER[] = _("MIRAGE TOWER");
@@ -1125,13 +1123,6 @@ const struct RegionMapLocation gRegionMapEntries[] = {
         .height = 1,
         .name = sMapName_UNDERGROUND_PATH_Clone,
     },
-    [MAPSEC_UNDERGROUND_PATH_2] = {
-        .x = 0,
-        .y = 0,
-        .width = 1,
-        .height = 1,
-        .name = sMapName_UNDERGROUND_PATH,
-    },
     [MAPSEC_KANTO_VICTORY_ROAD] = {
         .x = 0,
         .y = 0,
@@ -1432,6 +1423,62 @@ const struct RegionMapLocation gRegionMapEntries[] = {
         .width = 1,
         .height = 1,
         .name = sMapName_NAVEL_ROCK,
+    },
+    [MAPSEC_BERRY_FOREST] = {
+        .x = 0,
+        .y = 0,
+        .width = 1,
+        .height = 1,
+        .name = sMapName_BERRY_FOREST,
+    },
+    [MAPSEC_ICEFALL_CAVE] = {
+        .x = 0,
+        .y = 0,
+        .width = 1,
+        .height = 1,
+        .name = sMapName_ICEFALL_CAVE,
+    },
+    [MAPSEC_ROCKET_WAREHOUSE] = {
+        .x = 0,
+        .y = 0,
+        .width = 1,
+        .height = 1,
+        .name = sMapName_ROCKET_WAREHOUSE,
+    },
+    [MAPSEC_DOTTED_HOLE] = {
+        .x = 0,
+        .y = 0,
+        .width = 1,
+        .height = 1,
+        .name = sMapName_DOTTED_HOLE,
+    },
+    [MAPSEC_LOST_CAVE] = {
+        .x = 0,
+        .y = 0,
+        .width = 1,
+        .height = 1,
+        .name = sMapName_LOST_CAVE,
+    },
+    [MAPSEC_PATTERN_BUSH] = {
+        .x = 0,
+        .y = 0,
+        .width = 1,
+        .height = 1,
+        .name = sMapName_PATTERN_BUSH,
+    },
+    [MAPSEC_MT_EMBER] = {
+        .x = 0,
+        .y = 0,
+        .width = 1,
+        .height = 1,
+        .name = sMapName_MT__EMBER,
+    },
+    [MAPSEC_TRAINER_TOWER_2] = {
+        .x = 0,
+        .y = 0,
+        .width = 1,
+        .height = 1,
+        .name = sMapName_TRAINER_TOWER_Clone,
     },
     [MAPSEC_THREE_ISLE_PATH] = {
         .x = 0,

--- a/src/data/region_map/region_map_sections.json
+++ b/src/data/region_map/region_map_sections.json
@@ -835,11 +835,7 @@
     {
       "id": "MAPSEC_UNDERGROUND_PATH_2",
       "name": "UNDERGROUND PATH",
-      "name_clone": true
-    },
-    {
-      "id": "MAPSEC_UNDERGROUND_PATH_2",
-      "name": "UNDERGROUND PATH",
+      "name_clone": true,
       "x": 0,
       "y": 0,
       "width": 1,
@@ -1026,10 +1022,6 @@
       "name": "NAVEL ROCK"
     },
     {
-      "id": "MAPSEC_MT_EMBER",
-      "name": "MT. EMBER"
-    },
-    {
       "id": "MAPSEC_BERRY_FOREST",
       "name": "BERRY FOREST"
     },
@@ -1040,11 +1032,6 @@
     {
       "id": "MAPSEC_ROCKET_WAREHOUSE",
       "name": "ROCKET WAREHOUSE"
-    },
-    {
-      "id": "MAPSEC_TRAINER_TOWER_2",
-      "name": "TRAINER TOWER",
-      "name_clone": true
     },
     {
       "id": "MAPSEC_DOTTED_HOLE",
@@ -1067,44 +1054,13 @@
       "height": 1
     },
     {
-      "id": "MAPSEC_MONEAN_CHAMBER",
-      "name": "MONEAN CHAMBER"
-    },
-    {
-      "id": "MAPSEC_LIPTOO_CHAMBER",
-      "name": "LIPTOO CHAMBER"
-    },
-    {
-      "id": "MAPSEC_WEEPTH_CHAMBER",
-      "name": "WEEPTH CHAMBER"
-    },
-    {
       "id": "MAPSEC_TRAINER_TOWER_2",
       "name": "TRAINER TOWER",
+      "name_clone": true,
       "x": 0,
       "y": 0,
       "width": 1,
       "height": 1
-    },
-    {
-      "id": "MAPSEC_SCUFIB_CHAMBER",
-      "name": "SCUFIB CHAMBER"
-    },
-    {
-      "id": "MAPSEC_RIXY_CHAMBER",
-      "name": "RIXY CHAMBER"
-    },
-    {
-      "id": "MAPSEC_VIAPOIS_CHAMBER",
-      "name": "VIAPOIS CHAMBER"
-    },
-    {
-      "id": "MAPSEC_EMBER_SPA",
-      "name": "EMBER SPA"
-    },
-    {
-      "id": "MAPSEC_SPECIAL_AREA",
-      "name": "SPECIAL AREA"
     },
     {
       "id": "MAPSEC_THREE_ISLE_PATH",


### PR DESCRIPTION
## Summary
- deduplicate sevii region map section definitions
- regenerate `region_map_sections.h` and `region_map_entries.h`

## Testing
- `make include/constants/region_map_sections.h src/data/region_map/region_map_entries.h`

------
https://chatgpt.com/codex/tasks/task_e_687ab6809ff48323886d224a604ae48e