### PR TITLE
Fix duplicate clean-tools rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,8 +238,6 @@ syms: $(SYM)
 clean: tidy clean-tools clean-generated clean-assets
 	@$(MAKE) clean -C libagbsyscall
 
-clean-tools:
-	@$(foreach tooldir,$(TOOLDIRS),$(MAKE) clean -C $(tooldir);)
 
 mostlyclean: tidynonmodern tidymodern
 	find sound -iname '*.bin' -exec rm {} +


### PR DESCRIPTION
## Summary
- remove redundant `clean-tools` rule from `Makefile` to avoid override warnings

## Testing
- `make clean-tools`

------
https://chatgpt.com/codex/tasks/task_e_687aba0423d08323a37d1a88351a32c0