### PR TITLE
Fix linker error by keeping .data sections

### DIFF
--- a/ld_script.ld
+++ b/ld_script.ld
@@ -1344,7 +1344,9 @@ SECTIONS {
     {
         src/*.o(.text);
         src/*.o(.rodata);
+        src/*.o(.data);
         data/*.o(.rodata);
+        data/*.o(.data);
     } > ROM = 0
 
     /* DWARF debug sections.

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -86,6 +86,13 @@ SECTIONS {
         data/*.o(.rodata*);
     } > ROM =0
 
+    .data :
+    ALIGN(4)
+    {
+        src/*.o(.data*);
+        data/*.o(.data*);
+    } > ROM =0
+
     song_data :
     ALIGN(4)
     {


### PR DESCRIPTION
## Summary
- keep `.data` sections in `ld_script.ld`
- keep `.data` sections in `ld_script_modern.ld`

This prevents the linker from discarding object file data sections that are still referenced from code.

## Testing
- `make -j4` *(fails: `arm-none-eabi-as: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_687acb0cab588323bbb19220f5363302