### PR TITLE
Fix undefined metatile references

### DIFF
--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -360,6 +360,12 @@
 #define METATILE_LilycoveMuseum_Painting4_Right  0x263
 
 // gTileset_Lilycove
+#define METATILE_Lilycove_Wailmer0        0x11C0
+#define METATILE_Lilycove_Wailmer1        0x11C1
+#define METATILE_Lilycove_Wailmer2        0x11C2
+#define METATILE_Lilycove_Wailmer3        0x11C3
+#define METATILE_Lilycove_Wailmer0_Alt    0x11C4
+#define METATILE_Lilycove_Wailmer1_Alt    0x11C5
 #define METATILE_Lilycove_Door             0x3F6
 #define METATILE_Lilycove_Door_Wooden      0x3F7
 #define METATILE_Lilycove_Door_DeptStore   0x3F8


### PR DESCRIPTION
## Summary
- add missing Lilycove Wailmer metatile definitions

## Testing
- `make --version`
- `make -n` *(fails: `jsonproc` not built)*

------
https://chatgpt.com/codex/tasks/task_e_687acb17ad4c8323ade664e6fa7f2294