### PR TITLE
Fix overlapping ROM sections

### DIFF
--- a/ld_script.ld
+++ b/ld_script.ld
@@ -13,8 +13,9 @@ MEMORY
 /* Modify the following load addresses as needed to make more room. Alternately, delete both the
    declarations below and their references further down to get rid of the gaps.                  */
 
-__anim_mon_load_address = 0x8b00000;
-__gfx_load_address = 0x8c00000;
+/* Adjusted to avoid ROM overlap with song_data */
+__anim_mon_load_address = 0x8b70000;
+__gfx_load_address = 0x8d00000;
 
 SECTIONS {
 


### PR DESCRIPTION
## Summary
- adjust `__anim_mon_load_address` and `__gfx_load_address` in `ld_script.ld`
- this prevents the `anim_mon_front_pic_data` section from overlapping `song_data`

## Testing
- `make -j4` *(fails: arm-none-eabi-as not found)*

------
https://chatgpt.com/codex/tasks/task_e_687acaf30274832384e4c72616ce316b