### PR TITLE
Fix overlapped sections in ROM build

### DIFF
--- a/ld_script.ld
+++ b/ld_script.ld
@@ -14,7 +14,8 @@ MEMORY
    declarations below and their references further down to get rid of the gaps.                  */
 
 /* Adjusted to avoid ROM overlap with song_data */
-__anim_mon_load_address = 0x8b70000;
+/* Move start of animated front pics to avoid overlap with multiboot_data */
+__anim_mon_load_address = 0x8ba0000;
 __gfx_load_address = 0x8d00000;
 
 SECTIONS {


### PR DESCRIPTION
## Summary
- shift `__anim_mon_load_address` higher to avoid overlapping `multiboot_data`

## Testing
- `make -j4` *(fails: `arm-none-eabi-as: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_687ad3a6af9c8323a2e73e4305d7cf2a