### PR TITLE
Add Fame Checker stub feature

### DIFF
--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -345,9 +345,17 @@ PlayersHouse_1F_EventScript_TryGiveAmuletCoin::
 	end
 
 PlayersHouse_1F_EventScript_MomHealsParty::
-	msgbox PlayersHouse_1F_Text_YouShouldRestABit, MSGBOX_DEFAULT
-	goto PlayersHouse_1F_EventScript_HealParty
-	end
+        msgbox PlayersHouse_1F_Text_YouShouldRestABit, MSGBOX_DEFAULT
+        goto PlayersHouse_1F_EventScript_HealParty
+        end
+
+PlayersHouse_1F_EventScript_GiveFameChecker::
+        giveitem ITEM_FAME_CHECKER
+        goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
+        msgbox PlayersHouse_1F_Text_GotFameChecker, MSGBOX_DEFAULT
+        setflag FLAG_RECEIVED_FAME_CHECKER
+        release
+        end
 
 PlayersHouse_1F_EventScript_SeeYouHoney::
 	msgbox PlayersHouse_1F_Text_SeeYouHoney, MSGBOX_DEFAULT
@@ -673,3 +681,7 @@ PlayersHouse_1F_Movement_PlayerApproachTVForLatiFemale:
 EventScript_RunningShoesManual::
 	msgbox PlayersHouse_1F_Text_RunningShoesManual, MSGBOX_SIGN
 	end
+PlayersHouse_1F_Text_GotFameChecker:
+        .string "MOM: This device lets you read what\n"
+        .string "others say about famous TRAINERS.\p"
+        .string "It might help you become one, too!$"

--- a/include/fame_checker.h
+++ b/include/fame_checker.h
@@ -1,0 +1,6 @@
+#ifndef GUARD_FAME_CHECKER_H
+#define GUARD_FAME_CHECKER_H
+
+void CB2_OpenFameChecker(void);
+
+#endif // GUARD_FAME_CHECKER_H

--- a/src/fame_checker.c
+++ b/src/fame_checker.c
@@ -1,0 +1,9 @@
+#include "global.h"
+#include "fame_checker.h"
+#include "main.h"
+
+void CB2_OpenFameChecker(void)
+{
+    // Placeholder for fame checker feature
+    SetMainCallback2(CB2_ReturnToFieldContinueScriptPlayMapMusic);
+}


### PR DESCRIPTION
## Summary
- revert previous merge attempt
- add stub Fame Checker item handling
- give player the Fame Checker at home

## Testing
- `make -j2` *(fails: `arm-none-eabi-as: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_687adff49fec83239f936d53bdaf7981